### PR TITLE
add CTA functionality

### DIFF
--- a/agentstack/cli/cli.py
+++ b/agentstack/cli/cli.py
@@ -7,7 +7,6 @@ from typing import Optional
 from art import text2art
 import inquirer
 import os
-import webbrowser
 import importlib.resources
 from cookiecutter.main import cookiecutter
 

--- a/agentstack/generation/tool_generation.py
+++ b/agentstack/generation/tool_generation.py
@@ -36,6 +36,8 @@ def add_tool(tool_name: str, path: Optional[str] = None):
                     json.dump(agentstack_json, f, indent=4)
 
                 print(term_color(f'🔨 Tool {tool_name} added to agentstack project successfully', 'green'))
+                if tool_data.get('cta'):
+                    print(term_color(f'🪩 {tool_data["cta"]}', 'blue'))
 
 
 def add_tool_to_tools_init(tool_data: dict, path: Optional[str] = None):

--- a/agentstack/tools/browserbase.json
+++ b/agentstack/tools/browserbase.json
@@ -2,5 +2,6 @@
   "name": "browserbase",
   "package": "poetry add browserbase crewai-tools",
   "env": "BROWSERBASE_API_KEY=...\nBROWSERBASE_PROJECT_ID=...",
-  "tools": ["browserbase"]
+  "tools": ["browserbase"],
+  "cta": "Create an API key at https://www.browserbase.com/"
 }

--- a/agentstack/tools/firecrawl.json
+++ b/agentstack/tools/firecrawl.json
@@ -2,5 +2,6 @@
   "name": "firecrawl",
   "package": "poetry add firecrawl-py",
   "env": "FIRECRAWL_API_KEY=...",
-  "tools": ["web_scrape", "web_crawl", "retrieve_web_crawl"]
+  "tools": ["web_scrape", "web_crawl", "retrieve_web_crawl"],
+  "cta": "Create an API key at https://www.firecrawl.dev/"
 }

--- a/agentstack/tools/ftp.json
+++ b/agentstack/tools/ftp.json
@@ -2,5 +2,6 @@
   "name": "ftp",
   "package": "",
   "env": "FTP_HOST=...\nFTP_USER=...\nFTP_PASSWORD=...",
-  "tools": ["upload_files"]
+  "tools": ["upload_files"],
+  "cta": "Be sure to add your FTP credentials to .env"
 }

--- a/agentstack/tools/mem0.json
+++ b/agentstack/tools/mem0.json
@@ -2,5 +2,6 @@
   "name": "mem0",
   "package": "poetry add mem0ai",
   "env": "NEO4J_URL=...\nNEO4J_USERNAME=...\nNEO4J_PASSWORD=...",
-  "tools": ["write_to_memory", "read_from_memory"]
+  "tools": ["write_to_memory", "read_from_memory"],
+  "cta": "Optionally: setup your graph db hosting at https://app.mem0.ai/login"
 }

--- a/agentstack/utils.py
+++ b/agentstack/utils.py
@@ -64,12 +64,21 @@ def clean_input(input_string):
 
 
 def term_color(text: str, color: str) -> str:
-    if color is 'red':
-        return "\033[91m{}\033[00m".format(text)
-    if color is 'green':
-        return "\033[92m{}\033[00m".format(text)
+    colors = {
+        'red': '91',
+        'green': '92',
+        'yellow': '93',
+        'blue': '94',
+        'purple': '95',
+        'cyan': '96',
+        'white': '97'
+    }
+    color_code = colors.get(color)
+    if color_code:
+        return f"\033[{color_code}m{text}\033[00m"
     else:
         return text
+
 
 
 def is_snake_case(string: str):


### PR DESCRIPTION
After installing a tool, tool providers can optionally include a call to action instructing the user what to do next

Ex: `Create an API key at https://xxx.xxx/`