### PR TITLE
Drop python 3.9 support

### DIFF
--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.11,3.12]
+        python-version: [3.10,3.11,3.12]
 
     steps:
       - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 license = { text = "MIT" }
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 dependencies = [
     "typer>=0.12.5",

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py39,py310,py311,py312
+envlist = py310,py311,py312
 
 [testenv]
 deps =


### PR DESCRIPTION
This resolves an issue with testing Python3.9