### PR TITLE
preserve comments with AST

### DIFF
--- a/agentstack/generation/tool_generation.py
+++ b/agentstack/generation/tool_generation.py
@@ -378,7 +378,6 @@ def modify_agent_tools(
 
     filename = _framework_filename(framework, path)
 
-    # Read the original source and store line information
     with open(filename, 'r', encoding='utf-8') as f:
         source_lines = f.readlines()
 
@@ -389,7 +388,6 @@ def modify_agent_tools(
         if stripped.startswith('#'):
             comments[i + 1] = line
 
-    # Parse and modify the AST
     tree = ast.parse(''.join(source_lines))
 
     class ModifierTransformer(ast.NodeTransformer):
@@ -397,21 +395,15 @@ def modify_agent_tools(
             return _modify_agent_tools(node, tool_data, operation, agents, base_name)
 
     modified_tree = ModifierTransformer().visit(tree)
-
-    # Generate the modified source without comments
     modified_source = astor.to_source(modified_tree)
-
-    # Split the modified source into lines
     modified_lines = modified_source.splitlines()
 
-    # Reinsert comments at appropriate positions
+    # Reinsert comments
     final_lines = []
     for i, line in enumerate(modified_lines, 1):
-        # If there was a comment at this line number in the original file, add it
         if i in comments:
             final_lines.append(comments[i])
         final_lines.append(line + '\n')
 
-    # Write the final source back
     with open(filename, 'w', encoding='utf-8') as f:
         f.write(''.join(final_lines))

--- a/agentstack/generation/tool_generation.py
+++ b/agentstack/generation/tool_generation.py
@@ -378,17 +378,40 @@ def modify_agent_tools(
 
     filename = _framework_filename(framework, path)
 
-    with open(filename, 'r') as f:
-        source = f.read()
+    # Read the original source and store line information
+    with open(filename, 'r', encoding='utf-8') as f:
+        source_lines = f.readlines()
 
-    tree = ast.parse(source)
+    # Create a map of line numbers to comments
+    comments = {}
+    for i, line in enumerate(source_lines):
+        stripped = line.strip()
+        if stripped.startswith('#'):
+            comments[i + 1] = line
+
+    # Parse and modify the AST
+    tree = ast.parse(''.join(source_lines))
 
     class ModifierTransformer(ast.NodeTransformer):
         def visit_FunctionDef(self, node):
             return _modify_agent_tools(node, tool_data, operation, agents, base_name)
 
     modified_tree = ModifierTransformer().visit(tree)
+
+    # Generate the modified source without comments
     modified_source = astor.to_source(modified_tree)
 
-    with open(filename, 'w') as f:
-        f.write(modified_source)
+    # Split the modified source into lines
+    modified_lines = modified_source.splitlines()
+
+    # Reinsert comments at appropriate positions
+    final_lines = []
+    for i, line in enumerate(modified_lines, 1):
+        # If there was a comment at this line number in the original file, add it
+        if i in comments:
+            final_lines.append(comments[i])
+        final_lines.append(line + '\n')
+
+    # Write the final source back
+    with open(filename, 'w', encoding='utf-8') as f:
+        f.write(''.join(final_lines))

--- a/examples/web_researcher/src/crew.py
+++ b/examples/web_researcher/src/crew.py
@@ -7,6 +7,7 @@ import tools
 class WebresearcherCrew:
     """web_researcher crew"""
 
+    # Agent definitions
     @agent
     def content_summarizer(self) ->Agent:
         return Agent(config=self.agents_config['content_summarizer'], tools
@@ -23,6 +24,7 @@ class WebresearcherCrew:
             tools.create_database, tools.execute_sql_ddl, tools.
             run_sql_query], verbose=True)
 
+    # Task definitions
     @task
     def scrape_site(self) ->Task:
         return Task(config=self.tasks_config['scrape_site'])


### PR DESCRIPTION
While testing #77 i noticed that adding an agent failed because the `# Agent definitions` tag had disappeared after the file was modified with AST.

This is a simple fix that records comments in the original and inserts them while arranging the file via AST