### PR TITLE
Load .env first and favor it over system vars

### DIFF
--- a/agentstack/generation/files.py
+++ b/agentstack/generation/files.py
@@ -123,7 +123,11 @@ class EnvFile:
     def write(self):
         with open(self._path / self._filename, 'a') as f:
             for key, value in self._new_variables.items():
-                f.write(f"\n{key}={value}")
+                """
+                We don't want to override values the user may already have set
+                in their environment variables so we add a new line commented out.
+                """
+                f.write(f"\n# {key}={value}")
 
     def __enter__(self) -> 'EnvFile':
         return self

--- a/agentstack/templates/crewai/{{cookiecutter.project_metadata.project_slug}}/src/main.py
+++ b/agentstack/templates/crewai/{{cookiecutter.project_metadata.project_slug}}/src/main.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
+from dotenv import load_dotenv
+load_dotenv(override=True)
 import sys
 from crew import {{cookiecutter.project_metadata.project_name|replace('-', '')|replace('_', '')|capitalize}}Crew
 import agentops
-from dotenv import load_dotenv
-load_dotenv()
 
 agentops.init(default_tags=['crewai', 'agentstack'])
 


### PR DESCRIPTION
## 📥 Pull Request

Fixes #98 

**📘 Description**
Not sure if this is the most elegant solution but it fixes an issue where the template environment variable values "`...`" would persist and cause an error on `agenstack run` due to `Client` not being populated with the proper values defined in `.env` such as AGENTOPS_API_KEY.

Loading the envs before loading the module and favoring `.env` over system vars (which I suspect should be the recommended behavior: local config > system config) ensures that `Client` is properly configured with values from `.env`

**🧪 Testing**
The `agentstack run` command is able to successfully connect to my AgentOps account using the API key found on `.env`

