### PR TITLE
Disable update check in test environment

### DIFF
--- a/agentstack/update.py
+++ b/agentstack/update.py
@@ -68,6 +68,10 @@ def load_update_data():
 
 def should_update() -> bool:
     """Has it been longer than CHECK_EVERY since the last update check?"""
+    # Allow disabling update checks with an environment variable
+    if 'AGENTSTACK_UPDATE_DISABLE' in os.environ:
+        return False
+
     # Always check for updates in CI
     if _is_ci_environment():
         return True

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,9 @@
+import os
+import unittest
+from agentstack.update import should_update
+
+
+class UpdateTest(unittest.TestCase):
+    def test_updates_disabled_by_env_var_in_test(self):
+        assert 'AGENTSTACK_UPDATE_DISABLE' in os.environ
+        assert not should_update()

--- a/tox.ini
+++ b/tox.ini
@@ -16,3 +16,4 @@ commands =
     mypy: mypy agentops
 setenv = 
     AGENTSTACK_TELEMETRY_OPT_OUT = 1
+    AGENTSTACK_UPDATE_DISABLE = 1


### PR DESCRIPTION
Add `AGENTSTACK_UPDATE_DISABLE` environment variable to disable automatic update checks. 