### PR TITLE
Interactively add tools with `agentstack tools add` if no tool_name is passed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ A list of all tools can be found [on our docs](https://docs.agentstack.sh/tools/
 Adding tools is as simple as
 
 ```bash
-agentstack tools add <tool_name>
+agentstack tools add
 ```
 
 ## Running Your Agent

--- a/agentstack/cli/__init__.py
+++ b/agentstack/cli/__init__.py
@@ -1,2 +1,3 @@
-from .cli import init_project_builder, list_tools, configure_default_model, export_template
+from .cli import init_project_builder, configure_default_model, export_template
+from .tools import list_tools, add_tool
 from .run import run_project

--- a/agentstack/cli/cli.py
+++ b/agentstack/cli/cli.py
@@ -6,8 +6,6 @@ from pathlib import Path
 
 import json
 import shutil
-import itertools
-
 from art import text2art
 import inquirer
 from cookiecutter.main import cookiecutter
@@ -22,7 +20,6 @@ from agentstack.logger import log
 from agentstack import conf
 from agentstack.conf import ConfigFile
 from agentstack.utils import get_package_path
-from agentstack.tools import get_all_tools
 from agentstack.generation.files import ProjectFile
 from agentstack import frameworks
 from agentstack import generation
@@ -438,25 +435,6 @@ def insert_template(
         "    agentstack run\n\n"
         "  Run `agentstack quickstart` or `agentstack docs` for next steps.\n"
     )
-
-
-def list_tools():
-    # Display the tools
-    tools = get_all_tools()
-    curr_category = None
-
-    print("\n\nAvailable AgentStack Tools:")
-    for category, tools in itertools.groupby(tools, lambda x: x.category):
-        if curr_category != category:
-            print(f"\n{category}:")
-            curr_category = category
-        for tool in tools:
-            print("  - ", end='')
-            print(term_color(f"{tool.name}", 'blue'), end='')
-            print(f": {tool.url if tool.url else 'AgentStack default tool'}")
-
-    print("\n\n✨ Add a tool with: agentstack tools add <tool_name>")
-    print("   https://docs.agentstack.sh/tools/core")
 
 
 def export_template(output_filename: str):

--- a/agentstack/cli/tools.py
+++ b/agentstack/cli/tools.py
@@ -1,0 +1,69 @@
+from typing import Optional
+import itertools
+import inquirer
+from agentstack.utils import term_color
+from agentstack import generation
+from agentstack.tools import get_all_tools
+from agentstack.agents import get_all_agents
+
+
+def list_tools():
+    """
+    List all available tools by category.
+    """
+    tools = get_all_tools()
+    curr_category = None
+
+    print("\n\nAvailable AgentStack Tools:")
+    for category, tools in itertools.groupby(tools, lambda x: x.category):
+        if curr_category != category:
+            print(f"\n{category}:")
+            curr_category = category
+        for tool in tools:
+            print("  - ", end='')
+            print(term_color(f"{tool.name}", 'blue'), end='')
+            print(f": {tool.url if tool.url else 'AgentStack default tool'}")
+
+    print("\n\n✨ Add a tool with: agentstack tools add <tool_name>")
+    print("   https://docs.agentstack.sh/tools/core")
+
+
+def add_tool(tool_name: Optional[str], agents=Optional[list[str]]):
+    """
+    Add a tool to the user's project.
+    If no tool name is provided:
+        - prompt the user to select a tool
+        - prompt the user to select one or more agents
+    If a tool name is provided:
+        - add the tool to the user's project
+        - add the tool to the specified agents or all agents if none are specified
+    """
+    if not tool_name:
+        # ask the user for the tool name
+        tools_list = [
+            inquirer.List(
+                "tool_name",
+                message="Select a tool to add to your project",
+                choices=[tool.name for tool in get_all_tools()],
+            )
+        ]
+        try:
+            tool_name = inquirer.prompt(tools_list)['tool_name']
+        except TypeError:
+            return  # user cancelled the prompt
+
+        # ask the user for the agents to add the tool to
+        agents_list = [
+            inquirer.Checkbox(
+                "agents",
+                message="Select which agents to make the tool available to",
+                choices=[agent.name for agent in get_all_agents()],
+            )
+        ]
+        try:
+            agents = inquirer.prompt(agents_list)['agents']
+        except TypeError:
+            return  # user cancelled the prompt
+
+    assert tool_name  # appease type checker
+    generation.add_tool(tool_name, agents=agents)

--- a/agentstack/main.py
+++ b/agentstack/main.py
@@ -5,6 +5,7 @@ import webbrowser
 from agentstack import conf
 from agentstack.cli import (
     init_project_builder,
+    add_tool,
     list_tools,
     configure_default_model,
     run_project,
@@ -120,7 +121,7 @@ def main():
     tools_add_parser = tools_subparsers.add_parser(
         "add", aliases=["a"], help="Add a new tool", parents=[global_parser]
     )
-    tools_add_parser.add_argument("name", help="Name of the tool to add")
+    tools_add_parser.add_argument("name", help="Name of the tool to add", nargs="?")
     tools_add_parser.add_argument(
         "--agents", "-a", help="Name of agents to add this tool to, comma separated"
     )
@@ -179,7 +180,7 @@ def main():
         elif args.tools_command in ["add", "a"]:
             agents = [args.agent] if args.agent else None
             agents = args.agents.split(",") if args.agents else agents
-            generation.add_tool(args.name, agents=agents)
+            add_tool(args.name, agents)
         elif args.tools_command in ["remove", "r"]:
             generation.remove_tool(args.name)
         else:

--- a/agentstack/templates/crewai/{{cookiecutter.project_metadata.project_slug}}/README.md
+++ b/agentstack/templates/crewai/{{cookiecutter.project_metadata.project_slug}}/README.md
@@ -15,7 +15,7 @@ This will automatically create a new agent in the `agents.yaml` config as well a
 
 Similarly, tasks can be created with `agentstack g t <tool_name>`
 
-Add tools with `agentstack tools add <tool_name>` and view tools available with `agentstack tools list`
+Add tools with `agentstack tools add` and view tools available with `agentstack tools list`
 
 ## How to use your Crew
 In this directory, run `poetry install`  

--- a/docs/tools/tools.mdx
+++ b/docs/tools/tools.mdx
@@ -7,5 +7,10 @@ description: 'Giving your agents tools should be easy'
 
 Once you find the right tool for your use-case, install it with simply
 ```bash
-agentstack tools add <tool_name>
+agentstack tools add
+```
+
+You can also specify a tool, and one or more agents to install it to:
+```bash
+agentstack tools add <tool_name> --agents=<agent_name1>,<agent_name2>
 ```


### PR DESCRIPTION
Repeatedly add tools to different agents without reinstalling all supporting tools. 

Bugfix: Prevent duplicate tools from being added to the same agent.