### PR TITLE
exit on init failure

### DIFF
--- a/agentstack/cli/cli.py
+++ b/agentstack/cli/cli.py
@@ -46,15 +46,15 @@ def init_project_builder(
 ):
     if not slug_name and not use_wizard:
         print(term_color("Project name is required. Use `agentstack init <project_name>`", 'red'))
-        return
+        sys.exit(1)
 
     if slug_name and not is_snake_case(slug_name):
         print(term_color("Project name must be snake case", 'red'))
-        return
+        sys.exit(1)
 
     if template is not None and use_wizard:
         print(term_color("Template and wizard flags cannot be used together", 'red'))
-        return
+        sys.exit(1)
 
     template_data = None
     if template is not None:

--- a/agentstack/cli/cli.py
+++ b/agentstack/cli/cli.py
@@ -45,16 +45,13 @@ def init_project_builder(
     use_wizard: bool = False,
 ):
     if not slug_name and not use_wizard:
-        print(term_color("Project name is required. Use `agentstack init <project_name>`", 'red'))
-        sys.exit(1)
+        raise Exception("Project name is required. Use `agentstack init <project_name>`")
 
     if slug_name and not is_snake_case(slug_name):
-        print(term_color("Project name must be snake case", 'red'))
-        sys.exit(1)
+        raise Exception("Project slug name must be snake_case")
 
     if template is not None and use_wizard:
-        print(term_color("Template and wizard flags cannot be used together", 'red'))
-        sys.exit(1)
+        raise Exception("Template and wizard flags cannot be used together")
 
     template_data = None
     if template is not None:


### PR DESCRIPTION
## 📥 Pull Request

**📘 Description**
Currently, if the project init fails on any of these conditions, it continues to attempt to create the project and fails later. We should just exit on the failure.

**🧪 Testing**
locally

