### PR TITLE
fix: consolidate duplicate tool categories in list output

### DIFF
--- a/agentstack/cli/tools.py
+++ b/agentstack/cli/tools.py
@@ -12,14 +12,19 @@ def list_tools():
     List all available tools by category.
     """
     tools = get_all_tools()
-    curr_category = None
-
+    categories = {}
+    
+    # Group tools by category
+    for tool in tools:
+        if tool.category not in categories:
+            categories[tool.category] = []
+        categories[tool.category].append(tool)
+    
     print("\n\nAvailable AgentStack Tools:")
-    for category, tools in itertools.groupby(tools, lambda x: x.category):
-        if curr_category != category:
-            print(f"\n{category}:")
-            curr_category = category
-        for tool in tools:
+    # Display tools by category
+    for category in sorted(categories.keys()):
+        print(f"\n{category}:")
+        for tool in categories[category]:
             print("  - ", end='')
             print(term_color(f"{tool.name}", 'blue'), end='')
             print(f": {tool.url if tool.url else 'AgentStack default tool'}")


### PR DESCRIPTION
- Replace itertools.groupby with dictionary-based grouping
- Ensure tools with same category are displayed together
- Fix redundant display of browsing and computer-control categories

## 📥 Pull Request

**📘 Description**
addresses #179 

**🧪 Testing**
<img width="912" alt="Screenshot 2025-01-06 at 11 43 32 PM" src="https://github.com/user-attachments/assets/8db4926a-d8f3-4757-a7fa-98c799cd4307" />

