### PR TITLE
Exclude tests from coverage, add badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AgentStack [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/release/python-3100/) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+# AgentStack [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/release/python-3100/) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) ![python-testing](https://github.com/agentops-ai/agentstack/actions/workflows/python-testing.yml/badge.svg) ![mypy](https://github.com/agentops-ai/agentstack/actions/workflows/mypy.yml/badge.svg) [![codecov.io](https://codecov.io/github/agentops-ai/agentstack/coverage.svg?branch=master)](https://codecov.io/github/agentops-ai/agentstack>?branch=master)
 
 <img alt="Logo" align="right" src="https://raw.githubusercontent.com/bboynton97/agentstack-docs/3491fe490ea535e7def74c83182dfa8dcfb1f562/logo/dark-sm.svg" width="20%" />
 

--- a/tox.ini
+++ b/tox.ini
@@ -27,8 +27,10 @@ source = .
 omit =
     **/tmp/**
     ./tmp/**/*
+    tests/**
 
 [coverage:report]
 omit =
     **/tmp/**
     ./tmp/**/*
+    tests/**


### PR DESCRIPTION
We're currently calculating coverage of tests themselves; ignore that directory. 
Add badges to README. 