### PR TITLE
Agentops tool fix

### DIFF
--- a/agentstack/__init__.py
+++ b/agentstack/__init__.py
@@ -2,7 +2,7 @@
 This it the beginning of the agentstack public API.
 
 Methods that have been imported into this file are expected to be used by the
-end user inside of their project.
+end user inside their project.
 """
 
 from typing import Callable
@@ -39,6 +39,5 @@ class ToolLoader:
 
     def __getitem__(self, tool_name: str) -> list[Callable]:
         return frameworks.get_tool_callables(tool_name)
-
 
 tools = ToolLoader()

--- a/agentstack/cli/run.py
+++ b/agentstack/cli/run.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, List
 import sys
 import traceback
 from pathlib import Path
@@ -93,7 +93,7 @@ def _import_project_module(path: Path):
     return project_module
 
 
-def run_project(command: str = 'run', cli_args: Optional[str] = None):
+def run_project(command: str = 'run', cli_args: Optional[List[str]] = None):
     """Validate that the project is ready to run and then run it."""
     verify_agentstack_project()
     

--- a/agentstack/frameworks/__init__.py
+++ b/agentstack/frameworks/__init__.py
@@ -116,7 +116,7 @@ def validate_project():
 def add_tool(tool: ToolConfig, agent_name: str):
     """
     Add a tool to the user's project.
-    The tool will have aready been installed in the user's application and have
+    The tool will have already been installed in the user's application and have
     all dependencies installed. We're just handling code generation here.
     """
     return get_framework_module(get_framework()).add_tool(tool, agent_name)

--- a/agentstack/frameworks/crewai.py
+++ b/agentstack/frameworks/crewai.py
@@ -181,7 +181,7 @@ class CrewFile(asttools.File):
         """
         Add new tools to be used by an agent.
 
-        Tool definitions are inside of the methods marked with an `@agent` decorator.
+        Tool definitions are inside the methods marked with an `@agent` decorator.
         The method returns a new class instance with the tools as a list of callables
         under the kwarg `tools`.
         """
@@ -330,6 +330,24 @@ def get_tool_callables(tool_name: str) -> list[Callable]:
     except ImportError:
         raise ValidationError("Could not import `crewai`. Is this an AgentStack CrewAI project?")
 
+    # TODO: remove after agentops fixes their issue
+    # wrap method with agentops tool event
+    def wrap_method(method: Callable) -> Callable:
+        def wrapped_method(*args, **kwargs):
+            import agentops
+            tool_event = agentops.ToolEvent(method.__name__)
+            result = method(*args, **kwargs)
+            agentops.record(tool_event)
+            return result
+
+        # Preserve all original attributes
+        wrapped_method.__name__ = method.__name__
+        wrapped_method.__doc__ = method.__doc__
+        wrapped_method.__module__ = method.__module__
+        wrapped_method.__qualname__ = method.__qualname__
+        wrapped_method.__annotations__ = getattr(method, '__annotations__', {})
+        return wrapped_method
+
     tool_funcs = []
     tool_config = ToolConfig.from_tool_name(tool_name)
     for tool_func_name in tool_config.tools:
@@ -338,6 +356,10 @@ def get_tool_callables(tool_name: str) -> list[Callable]:
         assert callable(tool_func), f"Tool function {tool_func_name} is not callable."
         assert tool_func.__doc__, f"Tool function {tool_func_name} is missing a docstring."
 
-        # apply the CrewAI tool decorator to the tool function
-        tool_funcs.append(_crewai_tool_decorator(tool_func))
+        # First wrap with agentops
+        agentops_wrapped = wrap_method(tool_func)
+        # Then apply CrewAI decorator last so it properly inherits from BaseTool
+        crewai_wrapped = _crewai_tool_decorator(agentops_wrapped)
+        tool_funcs.append(crewai_wrapped)
+
     return tool_funcs

--- a/docs/tools/tools.mdx
+++ b/docs/tools/tools.mdx
@@ -14,3 +14,7 @@ You can also specify a tool, and one or more agents to install it to:
 ```bash
 agentstack tools add <tool_name> --agents=<agent_name1>,<agent_name2>
 ```
+
+<Note>
+    Add your own tool to the AgentStack repo [here](/contributing/adding-tools)!
+</Note>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentstack"
-version = "0.2.5"
+version = "0.2.5.1"
 description = "The fastest way to build robust AI agents"
 authors = [
     { name="Braelyn Boynton", email="bboynton97@gmail.com" },


### PR DESCRIPTION
There is currently a major bug in AgentOps wherein tool use is not being captured with Crew agents.
This has proven to be a degradation of AgentStack workflows, so we're implementing a fix here.

> NOTE: this should be reverted once AgentOps fixes the underlying issue

Also some typing and spelling/grammer fixes