### PR TITLE
add tomli in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,7 @@ dependencies = [
     "python-dotenv>=1.0.1",
     "uv>=0.5.6",
     "tomli>=2.2.1"
-][tool.poetry.dependencies]
-
+]
 
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,9 @@ dependencies = [
     "appdirs>=1.4.4",
     "python-dotenv>=1.0.1",
     "uv>=0.5.6",
-]
+    "tomli>=2.2.1"
+][tool.poetry.dependencies]
+
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
## 📥 Pull Request
Was getting the following error when I `agentstack init <name>`. 

```
agentstack init example
Traceback (most recent call last):
File "/Users/paolo.delmundo/tmp/agentstack-test/.venv/bin/agentstack", line 5, in
from agentstack.main import main
File "/Users/paolo.delmundo/tmp/agentstack-test/.venv/lib/python3.10/site-packages/agentstack/main.py", line 7, in
from agentstack.cli import (
File "/Users/paolo.delmundo/tmp/agentstack-test/.venv/lib/python3.10/site-packages/agentstack/cli/init.py", line 1, in
from .cli import init_project_builder, configure_default_model, export_template, welcome_message
File "/Users/paolo.delmundo/tmp/agentstack-test/.venv/lib/python3.10/site-packages/agentstack/cli/cli.py", line 22, in
from agentstack.generation.files import ProjectFile
File "/Users/paolo.delmundo/tmp/agentstack-test/.venv/lib/python3.10/site-packages/agentstack/generation/init.py", line 3, in
from .tool_generation import add_tool, remove_tool
File "/Users/paolo.delmundo/tmp/agentstack-test/.venv/lib/python3.10/site-packages/agentstack/generation/tool_generation.py", line 11, in
from agentstack.generation.files import EnvFile
File "/Users/paolo.delmundo/tmp/agentstack-test/.venv/lib/python3.10/site-packages/agentstack/generation/files.py", line 10, in
import tomli as tomllib
ModuleNotFoundError: No module named 'tomli'
```

**📘 Description**
Fixed missing tomli dependency 


