### PR TITLE
[bug] add version to neon dependency and add check

### DIFF
--- a/agentstack/_tools/neon/config.json
+++ b/agentstack/_tools/neon/config.json
@@ -7,7 +7,7 @@
     },
     "dependencies": [
         "neon-api>=0.1.5",
-        "psycopg2-binary"
+        "psycopg2-binary==2.9.10"
     ],
     "tools": ["create_database", "execute_sql_ddl", "run_sql_query"],
     "cta": "Create an API key at https://www.neon.tech"


### PR DESCRIPTION
i tested neon after merging which was silly and ran into this:

```
uv: [error]
 error: Failed to parse: `neon-api>=0.1.5 psycopg2-binary`
  Caused by: Trailing `psycopg2-binary` is not allowed
neon-api>=0.1.5 psycopg2-binary
        ^^^^^^^^^^^^^^^^^^^^^^^
An error occurred: 
too many values to unpack (expected 2)
```

fixed by adding a version to the dep in tool config

also added a test to check for this in the future