### PR TITLE
Stream output of a user project with `serve`

### DIFF
--- a/agentstack/cli/run.py
+++ b/agentstack/cli/run.py
@@ -1,111 +1,12 @@
-from typing import Optional, List, Dict
-import sys
-import asyncio
-import traceback
-from pathlib import Path
-import importlib.util
-from dotenv import load_dotenv
-
+from typing import Optional
 from agentstack import conf, log
-from agentstack.exceptions import ValidationError
 from agentstack import inputs
-from agentstack import frameworks
-from agentstack.utils import get_framework, verify_agentstack_project
-
-MAIN_FILENAME: Path = Path("src/main.py")
-MAIN_MODULE_NAME = "main"
+from agentstack import run
 
 
-def format_friendly_error_message(exception: Exception):
-    """
-    Projects will throw various errors, especially on first runs, so we catch
-    them here and print a more helpful message.
-
-    In order to prevent us from having to import all possible backend exceptions
-    we do string matching on the exception type and traceback contents.
-    """
-    # TODO These end up being pretty framework-specific; consider individual implementations.
-    COMMON_LLM_ENV_VARS = (
-        'OPENAI_API_KEY',
-        'ANTHROPIC_API_KEY',
-    )
-
-    name = exception.__class__.__name__
-    message = str(exception)
-    tracebacks = traceback.format_exception(type(exception), exception, exception.__traceback__)
-
-    match (name, message, tracebacks):
-        # The user doesn't have an environment variable set for the LLM provider.
-        case ('AuthenticationError', m, t) if 'litellm.AuthenticationError' in t[-1]:
-            variable_name = [k for k in COMMON_LLM_ENV_VARS if k in message] or ["correct"]
-            return (
-                "We were unable to connect to the LLM provider. "
-                f"Ensure your .env file has the {variable_name[0]} variable set."
-            )
-        # This happens when the LLM configured for an agent is invalid.
-        case ('BadRequestError', m, t) if 'LLM Provider NOT provided' in t[-1]:
-            return (
-                "An invalid LLM was configured for an agent. "
-                "Ensure the 'llm' attribute of the agent in the agents.yaml file is in the format <provider>/<model>."
-            )
-        # The user has not configured the correct agent name in the tasks.yaml file.
-        case ('KeyError', m, t) if 'self.tasks_config[task_name]["agent"]' in t[-2]:
-            return (
-                f"The agent {message} is not defined in your agents file. "
-                "Ensure the 'agent' fields in your tasks.yaml correspond to an entry in the agents.yaml file."
-            )
-        # The user does not have an agent defined in agents.yaml file, but it does
-        # exist in the entrypoint code.
-        case ('KeyError', m, t) if 'config=self.agents_config[' in t[-2]:
-            return (
-                f"The agent {message} is not defined in your agents file. "
-                "Ensure all agents referenced in your code are defined in the agents.yaml file."
-            )
-        # The user does not have a task defined in tasks.yaml file, but it does
-        # exist in the entrypoint code.
-        case ('KeyError', m, t) if 'config=self.tasks_config[' in t[-2]:
-            return (
-                f"The task {message} is not defined in your tasks. "
-                "Ensure all tasks referenced in your code are defined in the tasks.yaml file."
-            )
-        case (_, _, _):
-            log.debug(
-                f"Unhandled exception; if this is a common error, consider adding it to "
-                f"`cli.run._format_friendly_error_message`. Exception: {exception}"
-            )
-            raise exception  # re-raise the original exception so we preserve context
-
-
-def _import_project_module(path: Path):
-    """
-    Import `main` from the project path.
-
-    We do it this way instead of spawning a subprocess so that we can share
-    state with the user's project.
-    """
-    spec = importlib.util.spec_from_file_location(MAIN_MODULE_NAME, str(path / MAIN_FILENAME))
-
-    assert spec is not None  # appease type checker
-    assert spec.loader is not None  # appease type checker
-
-    project_module = importlib.util.module_from_spec(spec)
-    sys.path.insert(0, str((path / MAIN_FILENAME).parent))
-    spec.loader.exec_module(project_module)
-    return project_module
-
-
-def run_project(command: str = 'run', cli_args: Optional[List[str]] = None):
+def run_project(command: str = 'run', cli_args: Optional[list[str]] = None):
     """Validate that the project is ready to run and then run it."""
-    conf.assert_project()
-    verify_agentstack_project()
-    
-    if conf.get_framework() not in frameworks.SUPPORTED_FRAMEWORKS:
-        raise ValidationError(f"Framework {conf.get_framework()} is not supported by agentstack.")
-
-    try:
-        frameworks.validate_project()
-    except ValidationError as e:
-        raise e
+    run.preflight()
 
     # Parse extra --input-* arguments for runtime overrides of the project's inputs
     if cli_args:
@@ -116,21 +17,5 @@ def run_project(command: str = 'run', cli_args: Optional[List[str]] = None):
             log.debug(f"Using CLI input override: {key}={value}")
             inputs.add_input_for_run(key, value)
 
-    load_dotenv(Path.home() / '.env')  # load the user's .env file
-    load_dotenv(conf.PATH / '.env', override=True)  # load the project's .env file
+    run.run_project(command=command)
 
-    # import src/main.py from the project path and run `command` from the project's main.py
-    try:
-        log.notify("Running your agent...")
-        project_main = _import_project_module(conf.PATH)
-        main = getattr(project_main, command)
-        
-        # handle both async and sync entrypoints
-        if asyncio.iscoroutinefunction(main):
-            asyncio.run(main())
-        else:
-            main()
-    except ImportError as e:
-        raise ValidationError(f"Failed to import AgentStack project at: {conf.PATH.absolute()}\n{e}")
-    except Exception as e:
-        raise Exception(format_friendly_error_message(e))

--- a/agentstack/frameworks/__init__.py
+++ b/agentstack/frameworks/__init__.py
@@ -6,7 +6,7 @@ from importlib import import_module
 from dataclasses import dataclass
 from pathlib import Path
 import ast
-from agentstack import conf
+from agentstack import conf, log
 from agentstack.exceptions import ValidationError
 from agentstack.generation import InsertionPoint
 from agentstack.utils import get_framework
@@ -22,6 +22,7 @@ CREWAI = 'crewai'
 LANGGRAPH = 'langgraph'
 OPENAI_SWARM = 'openai_swarm'
 LLAMAINDEX = 'llamaindex'
+CUSTOM = 'custom'
 SUPPORTED_FRAMEWORKS = [
     CREWAI,
     LANGGRAPH,
@@ -313,6 +314,9 @@ def get_framework_module(framework: str) -> FrameworkModule:
     """
     Get the module for a framework.
     """
+    if framework == CUSTOM:
+        raise Exception("Custom frameworks do not support modification.")
+    
     try:
         return import_module(f".{framework}", package=__package__)
     except ImportError:
@@ -332,6 +336,11 @@ def validate_project():
     Validate that the user's project is ready to run.
     """
     framework = get_framework()
+    
+    if framework == CUSTOM:
+        log.debug("Skipping validation for custom framework.")
+        return
+    
     entrypoint_path = get_entrypoint_path(framework)
     module = get_framework_module(framework)
     entrypoint = module.get_entrypoint()

--- a/agentstack/inputs.py
+++ b/agentstack/inputs.py
@@ -77,6 +77,8 @@ def get_inputs() -> dict:
     """
     Get the inputs configuration file and override with run_inputs.
     """
+    global run_inputs
+    
     config = InputsConfig().to_dict()
     # run_inputs override saved inputs
     for key, value in run_inputs.items():
@@ -89,4 +91,6 @@ def add_input_for_run(key: str, value: str):
     Add an input override for the current run.
     This is used by the CLI to allow inputs to be set at runtime.
     """
+    global run_inputs
+    
     run_inputs[key] = value

--- a/agentstack/log.py
+++ b/agentstack/log.py
@@ -51,6 +51,7 @@ DEBUG = logging.DEBUG  # 10
 TOOL_USE = 16
 THINKING = 18
 INFO = logging.INFO  # 20
+STREAM = 21
 NOTIFY = 22
 SUCCESS = 24
 RESPONSE = 26
@@ -59,6 +60,7 @@ ERROR = logging.ERROR  # 40
 
 logging.addLevelName(THINKING, 'THINKING')
 logging.addLevelName(TOOL_USE, 'TOOL_USE')
+logging.addLevelName(STREAM, 'STREAM')
 logging.addLevelName(NOTIFY, 'NOTIFY')
 logging.addLevelName(SUCCESS, 'SUCCESS')
 logging.addLevelName(RESPONSE, 'RESPONSE')
@@ -107,6 +109,7 @@ def _create_handler(levelno: int) -> Callable:
 debug = _create_handler(DEBUG)
 tool_use = _create_handler(TOOL_USE)
 thinking = _create_handler(THINKING)
+stream = _create_handler(STREAM)
 info = _create_handler(INFO)
 notify = _create_handler(NOTIFY)
 success = _create_handler(SUCCESS)
@@ -118,13 +121,14 @@ error = _create_handler(ERROR)
 class ConsoleFormatter(logging.Formatter):
     """Formats log messages for display in the console."""
 
-    default_format = logging.Formatter('%(message)s')
+    default_format = logging.Formatter('%(message)s\n')
     formats = {
-        DEBUG: logging.Formatter('DEBUG: %(message)s'),
-        SUCCESS: logging.Formatter(term_color('%(message)s', 'green')),
-        NOTIFY: logging.Formatter(term_color('%(message)s', 'blue')),
-        WARNING: logging.Formatter(term_color('%(message)s', 'yellow')),
-        ERROR: logging.Formatter(term_color('%(message)s', 'red')),
+        DEBUG: logging.Formatter('DEBUG: %(message)s\n'),
+        STREAM: logging.Formatter('%(message)s'),
+        SUCCESS: logging.Formatter(term_color('%(message)s\n', 'green')),
+        NOTIFY: logging.Formatter(term_color('%(message)s\n', 'blue')),
+        WARNING: logging.Formatter(term_color('%(message)s\n', 'yellow')),
+        ERROR: logging.Formatter(term_color('%(message)s\n', 'red')),
     }
 
     def format(self, record: logging.LogRecord) -> str:
@@ -135,9 +139,10 @@ class ConsoleFormatter(logging.Formatter):
 class FileFormatter(logging.Formatter):
     """Formats log messages for display in a log file."""
 
-    default_format = logging.Formatter('%(levelname)s: %(message)s')
+    default_format = logging.Formatter('%(levelname)s: %(message)s\n')
     formats = {
-        DEBUG: logging.Formatter('DEBUG (%(asctime)s):\n %(pathname)s:%(lineno)d\n %(message)s'),
+        DEBUG: logging.Formatter('DEBUG (%(asctime)s):\n %(pathname)s:%(lineno)d\n %(message)s\n'),
+        STREAM: logging.Formatter('%(message)s\n'),
     }
 
     def format(self, record: logging.LogRecord) -> str:
@@ -172,6 +177,7 @@ def _build_logger() -> logging.Logger:
         file_handler = logging.FileHandler(log_filename)
         file_handler.setFormatter(FileFormatter())
         file_handler.setLevel(DEBUG)
+        file_handler.terminator = ''
         log.addHandler(file_handler)
     except FileNotFoundError:
         pass  # we are not in a writeable directory
@@ -182,6 +188,7 @@ def _build_logger() -> logging.Logger:
     stdout_handler.setFormatter(ConsoleFormatter())
     stdout_handler.setLevel(DEBUG)
     stdout_handler.addFilter(lambda record: record.levelno < ERROR)
+    stdout_handler.terminator = ''
     log.addHandler(stdout_handler)
 
     # stderr handler for errors and above
@@ -189,6 +196,7 @@ def _build_logger() -> logging.Logger:
     stderr_handler = logging.StreamHandler(stderr)
     stderr_handler.setFormatter(ConsoleFormatter())
     stderr_handler.setLevel(ERROR)
+    stderr_handler.terminator = ''
     log.addHandler(stderr_handler)
 
     return log

--- a/agentstack/run.py
+++ b/agentstack/run.py
@@ -1,0 +1,132 @@
+from typing import Optional, List, Dict
+import sys
+import asyncio
+import traceback
+from pathlib import Path
+import importlib.util
+from dotenv import load_dotenv
+
+from agentstack import conf, log
+from agentstack.exceptions import ValidationError
+from agentstack import inputs
+from agentstack import frameworks
+from agentstack.utils import get_framework, verify_agentstack_project
+
+MAIN_FILENAME: Path = Path("src/main.py")
+MAIN_MODULE_NAME = "main"
+
+
+def format_friendly_error_message(exception: Exception):
+    """
+    Projects will throw various errors, especially on first runs, so we catch
+    them here and print a more helpful message.
+
+    In order to prevent us from having to import all possible backend exceptions
+    we do string matching on the exception type and traceback contents.
+    """
+    # TODO These end up being pretty framework-specific; consider individual implementations.
+    COMMON_LLM_ENV_VARS = (
+        'OPENAI_API_KEY',
+        'ANTHROPIC_API_KEY',
+    )
+
+    name = exception.__class__.__name__
+    message = str(exception)
+    tracebacks = traceback.format_exception(type(exception), exception, exception.__traceback__)
+
+    match (name, message, tracebacks):
+        # The user doesn't have an environment variable set for the LLM provider.
+        case ('AuthenticationError', m, t) if 'litellm.AuthenticationError' in t[-1]:
+            variable_name = [k for k in COMMON_LLM_ENV_VARS if k in message] or ["correct"]
+            return (
+                "We were unable to connect to the LLM provider. "
+                f"Ensure your .env file has the {variable_name[0]} variable set."
+            )
+        # This happens when the LLM configured for an agent is invalid.
+        case ('BadRequestError', m, t) if 'LLM Provider NOT provided' in t[-1]:
+            return (
+                "An invalid LLM was configured for an agent. "
+                "Ensure the 'llm' attribute of the agent in the agents.yaml file is in the format <provider>/<model>."
+            )
+        # The user has not configured the correct agent name in the tasks.yaml file.
+        case ('KeyError', m, t) if 'self.tasks_config[task_name]["agent"]' in t[-2]:
+            return (
+                f"The agent {message} is not defined in your agents file. "
+                "Ensure the 'agent' fields in your tasks.yaml correspond to an entry in the agents.yaml file."
+            )
+        # The user does not have an agent defined in agents.yaml file, but it does
+        # exist in the entrypoint code.
+        case ('KeyError', m, t) if 'config=self.agents_config[' in t[-2]:
+            return (
+                f"The agent {message} is not defined in your agents file. "
+                "Ensure all agents referenced in your code are defined in the agents.yaml file."
+            )
+        # The user does not have a task defined in tasks.yaml file, but it does
+        # exist in the entrypoint code.
+        case ('KeyError', m, t) if 'config=self.tasks_config[' in t[-2]:
+            return (
+                f"The task {message} is not defined in your tasks. "
+                "Ensure all tasks referenced in your code are defined in the tasks.yaml file."
+            )
+        case (_, _, _):
+            log.debug(
+                f"Unhandled exception; if this is a common error, consider adding it to "
+                f"`cli.run._format_friendly_error_message`. Exception: {exception}"
+            )
+            raise exception  # re-raise the original exception so we preserve context
+
+
+def _import_project_module(path: Path):
+    """
+    Import `main` from the project path.
+
+    We do it this way instead of spawning a subprocess so that we can share
+    state with the user's project.
+    """
+    spec = importlib.util.spec_from_file_location(MAIN_MODULE_NAME, str(path / MAIN_FILENAME))
+
+    assert spec is not None  # appease type checker
+    assert spec.loader is not None  # appease type checker
+
+    project_module = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str((path / MAIN_FILENAME).parent))
+    spec.loader.exec_module(project_module)
+    return project_module
+
+
+def preflight():
+    """Validate that the project is ready to run."""
+    conf.assert_project()
+    verify_agentstack_project()
+
+    # TODO ensure this is actually redundant, but it feels that way
+    # if conf.get_framework() not in frameworks.SUPPORTED_FRAMEWORKS:
+    #     raise ValidationError(f"Framework {conf.get_framework()} is not supported by agentstack.")
+
+    try:
+        frameworks.validate_project()
+    except ValidationError as e:
+        raise e
+
+
+def run_project(command: str = 'run', cli_args: Optional[List[str]] = None):
+    """Run a user project."""
+    load_dotenv(Path.home() / '.env')  # load the user's .env file
+    load_dotenv(conf.PATH / '.env', override=True)  # load the project's .env file
+
+    # import src/main.py from the project path and run `command` from the project's main.py
+    try:
+        log.notify("Running your agent...")
+        project_main = _import_project_module(conf.PATH)
+        main = getattr(project_main, command)
+        
+        # handle both async and sync entrypoints
+        if asyncio.iscoroutinefunction(main):
+            asyncio.run(main())
+        else:
+            main()
+    except ImportError as e:
+        raise ValidationError(f"Failed to import AgentStack project at: {conf.PATH.absolute()}\n{e}")
+    except Exception as e:
+        raise Exception(format_friendly_error_message(e))
+

--- a/agentstack/serve/serve.py
+++ b/agentstack/serve/serve.py
@@ -1,28 +1,55 @@
+from typing import Optional, Any, Callable, Generator
+import os, sys
+import io
+from threading import Thread
+import time
 import importlib
-import sys
+from enum import Enum
 from pathlib import Path
+import pydantic
 from urllib.parse import urlparse
-
-from dotenv import load_dotenv
-from agentstack import conf, frameworks, inputs, log
-from agentstack.exceptions import ValidationError
-from agentstack.utils import verify_agentstack_project
-# TODO: move this to not cli, but cant be utils due to circular import
-from agentstack.cli.run import format_friendly_error_message
-from flask import Flask, request, jsonify
+import json
 import requests
-from typing import Dict, Any, Optional, Tuple
-import os
+from dotenv import load_dotenv
 
-MAIN_FILENAME: Path = Path("src/main.py")
-MAIN_MODULE_NAME = "main"
+from flask import Flask, send_file, request, jsonify
+from flask import Response as BaseResponse
+from flask_sock import Sock
+from flask_cors import CORS
+
+from agentstack import conf, log
+from agentstack.exceptions import ValidationError
+from agentstack import inputs
+from agentstack import run
+
 
 load_dotenv(dotenv_path="/app/.env")
-app = Flask(__name__)
+#app = Flask(__name__)
 
-current_webhook_url = None
+#current_webhook_url = None
 
-def call_webhook(webhook_url: str, data: Dict[str, Any]) -> None:
+ALLOWED_ORIGINS = ['*']
+
+class Message(pydantic.BaseModel):
+    class Type(str, Enum):
+        CHAT = "chat"
+    
+    type: Type
+    data: dict[str, Any]
+
+
+# TODO subclass flask.Response for response types
+class Response(pydantic.BaseModel):
+    class Type(str, Enum):
+        DATA = "data"
+        SUCCESS = "success"
+        ERROR = "error"
+    
+    type: Type
+    data: Optional[dict[str, Any]] = None
+
+
+def call_webhook(webhook_url: str, data: dict[str, Any]) -> None:
     """Send results to the specified webhook URL."""
     try:
         response = requests.post(webhook_url, json=data)
@@ -31,65 +58,67 @@ def call_webhook(webhook_url: str, data: Dict[str, Any]) -> None:
         app.logger.error(f"Webhook call failed: {str(e)}")
         raise
 
-@app.route("/health", methods=["GET"])
-def health():
-    return "Agent Server Up"
 
-@app.route('/process', methods=['POST'])
-def process_agent():
-    global current_webhook_url
+# @app.route("/health", methods=["GET"])
+# def health():
+#     return "Agent Server Up"
 
-    request_data = None
-    try:
-        request_data = request.get_json()
+# @app.route('/process', methods=['POST'])
+# def process_agent():
+#     global current_webhook_url
 
-        if not request_data or 'webhook_url' not in request_data:
-            result, message = validate_url(request_data.get("webhook_url"))
-            if not result:
-                return jsonify({'error': f'Invalid webhook_url in request: {message}'}), 400
+#     request_data = None
+#     try:
+#         request_data = request.get_json()
 
-        if not request_data or 'inputs' not in request_data:
-            return jsonify({'error': 'Missing input data in request'}), 400
+#         if not request_data or 'webhook_url' not in request_data:
+#             result, message = validate_url(request_data.get("webhook_url"))
+#             if not result:
+#                 return jsonify({'error': f'Invalid webhook_url in request: {message}'}), 400
 
-        current_webhook_url = request_data.pop('webhook_url')
+#         if not request_data or 'inputs' not in request_data:
+#             return jsonify({'error': 'Missing input data in request'}), 400
 
-        return jsonify({
-            'status': 'accepted',
-            'message': 'Agent process started'
-        }), 202
+#         current_webhook_url = request_data.pop('webhook_url')
 
-    except Exception as e:
-        error_message = str(e)
-        app.logger.error(f"Error processing request: {error_message}")
-        return jsonify({
-            'status': 'error',
-            'error': error_message
-        }), 500
+#         return jsonify({
+#             'status': 'accepted',
+#             'message': 'Agent process started'
+#         }), 202
 
-    finally:
-        if current_webhook_url:
-            try:
-                result, session_id = run_project(api_inputs=request_data.get('inputs'))
-                call_webhook(current_webhook_url, {
-                    'status': 'success',
-                    'result': result,
-                    'session_id': session_id
-                })
-            except Exception as e:
-                error_message = str(e)
-                app.logger.error(f"Error in process: {error_message}")
-                try:
-                    call_webhook(current_webhook_url, {
-                        'status': 'error',
-                        'error': error_message
-                    })
-                except:
-                    app.logger.error("Failed to send error to webhook")
-            finally:
-                current_webhook_url = None
+#     except Exception as e:
+#         error_message = str(e)
+#         app.logger.error(f"Error processing request: {error_message}")
+#         return jsonify({
+#             'status': 'error',
+#             'error': error_message
+#         }), 500
 
-def run_project(command: str = 'run', api_args: Optional[Dict[str, str]] = None,
-                api_inputs: Optional[Dict[str, str]] = None):
+#     finally:
+#         if current_webhook_url:
+#             try:
+#                 result, session_id = run_project(api_inputs=request_data.get('inputs'))
+#                 call_webhook(current_webhook_url, {
+#                     'status': 'success',
+#                     'result': result,
+#                     'session_id': session_id
+#                 })
+#             except Exception as e:
+#                 error_message = str(e)
+#                 app.logger.error(f"Error in process: {error_message}")
+#                 try:
+#                     call_webhook(current_webhook_url, {
+#                         'status': 'error',
+#                         'error': error_message
+#                     })
+#                 except:
+#                     app.logger.error("Failed to send error to webhook")
+#             finally:
+#                 current_webhook_url = None
+
+
+def run_project(command: str = 'run', api_args: Optional[dict[str, str]] = None,
+                api_inputs: Optional[dict[str, str]] = None):
     """Validate that the project is ready to run and then run it."""
     # TODO `api_args` is unused
     run.preflight()
@@ -100,7 +129,50 @@ def run_project(command: str = 'run', api_args: Optional[Dict[str, str]] = None,
     run.run_project(command=command)
 
 
-def validate_url(url: str) -> Tuple[bool, str]:
+class GeneratorIO:
+    """Behaves like streamIO but is iterable"""
+    def __init__(self):
+        self.buffer = io.StringIO()
+        self._pos = 0
+    
+    def write(self, text: str) -> int:
+        self.buffer.write(text)
+        return len(text)
+    
+    def flush(self) -> None:
+        pass
+
+    def __iter__(self) -> Generator[str, None, None]:
+        while True:
+            self.buffer.seek(self._pos)
+            data = self.buffer.read()
+            if data:
+                self._pos = self.buffer.tell()
+                yield data
+            else:
+                break
+
+
+def run_project_stream(inputs: dict[str, str], command: str = 'run') -> Generator[str, None, None]:
+    """Validate that the project is ready to run and then run it."""
+    log_output = GeneratorIO()
+    log.set_stream(log_output)
+
+    thread = Thread(target=lambda: run_project(command=command, api_inputs=inputs))
+    thread.start()
+
+    while thread.is_alive():
+        for line in log_output:
+            yield line
+        time.sleep(0.1)
+    
+    for line in log_output:  # stragglers post-thread
+        yield line
+
+    thread.join()
+
+
+def validate_url(url: str) -> tuple[bool, str]:
     """Validates a URL and returns a tuple of (is_valid, error_message)."""
     if not url:
         return False, "URL cannot be empty"
@@ -125,12 +197,181 @@ def validate_url(url: str) -> Tuple[bool, str]:
     except Exception as e:
         return False, f"Invalid URL format: {str(e)}"
 
+
+class ProjectServer:
+    app: Flask
+    sock: Sock
+    webhook_url: Optional[str] = None
+    
+    def __init__(self):
+        self.app = Flask(__name__)
+        self.sock = Sock(self.app)
+        
+        CORS(self.app, 
+             origins=ALLOWED_ORIGINS,
+             methods=["*"])
+        self.register_routes()
+    
+    def register_routes(self):
+        """Register all routes for the application"""
+        routes = self.get_routes()
+        for route, handler, method in routes:
+            if method in ('GET', 'POST', 'PUT', 'DELETE'):
+                # Regular HTTP routes
+                self.app.route(route, methods=[method])(handler)
+            else:
+                # WebSocket routes
+                self.sock.route(route)(handler)
+    
+    def get_routes(self) -> list[tuple[str, Callable, str]]:
+        return [
+            ('/', self.index, 'GET'), 
+            ('/ws', self.websocket_handler, None), 
+            ('/health', self.health, 'GET'), 
+            ('/process', self.process, 'POST'),
+        ]
+    
+    def format_response(self, response: Response) -> BaseResponse:
+        """Dump a response object to JSON"""
+        return jsonify(response.model_dump())
+    
+    def index(self):
+        """Serve a user interface"""
+        # TODO delegate this to the user project. 
+        return send_file(conf.PATH / 'src/index.html'), 200
+    
+    def health(self) -> BaseResponse:
+        """Health check endpoint"""
+        response = Response(
+            type=Response.Type.DATA,
+            data={'status': 'ok'},
+        )
+        return self.format_response(response), 200
+    
+    def process(self) -> BaseResponse:
+        request_data = None
+        try:
+            request_data = request.get_json()
+
+            if not request_data or 'webhook_url' not in request_data:
+                result, message = validate_url(request_data.get("webhook_url"))
+                if not result:
+                    raise ValueError(f'Invalid webhook_url in request: {message}')
+            
+            if not request_data or 'inputs' not in request_data:
+                raise ValueError('Missing input data in request')
+
+            self.webhook_url = request_data.pop('webhook_url')
+            return self.format_response(Response(
+                type=Response.Type.SUCCESS,
+                data={'message': 'Agent process started'}
+            )), 202
+        
+        except Exception as e:
+            error_message = str(e)
+            # TODO agentstack.log?
+            app.logger.error(f"Error processing request: {error_message}")
+            return self.format_response(Response(
+                type=Response.Type.ERROR,
+                data={'message': error_message}
+            )), 500
+
+        finally:
+            if not self.webhook_url:
+                # TODO project will not run if we don't have a webhook url
+                # can we just yolo it into the void or should we tell the user first?
+                return
+
+            try:
+                assert request_data, "request_data is None"
+                # TODO `command`
+                result, session_id = run_project(api_inputs=request_data.get('inputs'))
+                call_webhook(current_webhook_url, {
+                    'status': 'success',
+                    'result': result,
+                    'session_id': session_id
+                })
+            except Exception as e:
+                error_message = str(e)
+                # TODO agentstack.log?
+                app.logger.error(f"Error in process: {error_message}")
+                try:
+                    call_webhook(current_webhook_url, {
+                        'status': 'error',
+                        'error': error_message
+                    })
+                except:
+                    # TODO agentstack.log?
+                    app.logger.error("Failed to send error to webhook")
+            finally:
+                self.webhook_url = None
+    
+    def handle_message(self, message: Message) -> Generator[Response, None, None]:
+        """Handle incoming messages"""
+        if message.type == Message.Type.CHAT:
+            assert 'role' in message.data
+            assert 'content' in message.data
+            
+            inputs = {
+                'prompt': message.data['content'],
+            }
+            
+            # TODO assistant is hardcoded
+            for content in run_project_stream(inputs):
+                yield Response(
+                    type=Response.Type.DATA,
+                    data={'role': 'assistant', 'content': content},
+                )
+                time.sleep(0.01)  # small delay to prevent overwhelming the socket
+    
+    def get_response(self, message: dict[str, Any]) -> Generator[Response, None, None]:
+        """Process incoming message and generate responses"""
+        try:
+            _message = Message.model_validate(message)
+            for response in self.handle_message(_message):
+                yield response
+        except ValueError as e:
+            yield Response(
+                type=Response.Type.ERROR,
+                data={'error': f"Invalid message format: {str(e)}"},
+            )
+        except Exception:
+            yield Response(
+                type=Response.Type.ERROR,
+                data={'error': "Unknown message type"},
+            )
+    
+    def websocket_handler(self, ws):
+        """Handle WebSocket connections"""
+        while True:
+            try:
+                raw_message = json.loads(ws.receive())
+                for response in self.get_response(raw_message):
+                    ws.send(json.dumps(response.model_dump()))
+            except Exception as e:
+                response = Response(
+                    type=Response.Type.ERROR,
+                    data={'error': str(e)}
+                )
+                ws.send(json.dumps(response.model_dump()))
+                break
+    
+    def run(self, host='0.0.0.0', port=6969, **kwargs):
+        """Run the Flask application"""
+        self.app.run(host=host, port=port, **kwargs)
+
+
 if __name__ == '__main__':
     port = int(os.environ.get('PORT', 6969))
     print("🚧 Running your agent on a development server")
     print(f"Send agent requests to http://localhost:{port}")
     print("Learn more about agent requests at https://docs.agentstack.sh/")  # TODO: add docs for this
 
+    log.set_stderr(sys.stderr)
+    log.set_stdout(sys.stdout)
+    conf.set_path(Path.cwd())
+    
+    app = ProjectServer()
     app.run(host='0.0.0.0', port=port)
 else:
     print("Starting production server with Gunicorn")

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -514,10 +514,6 @@ which adheres to a common pattern or exporting your project to share.
 Templates are versioned, and each previous version provides a method to convert
 it's content to the current version. 
 
-> TODO: Templates are currently identified as `proj_templates` since they conflict
-with the templates used by `generation`. Move existing templates to be part of
-the generation package. 
-
 ### `TemplateConfig.from_user_input(identifier: str)`
 `<TemplateConfig>` Returns a `TemplateConfig` object for either a URL, file path,
 or builtin template name.
@@ -716,7 +712,7 @@ title: 'System Analyzer'
 description: 'Inspect a project directory and improve it'
 ---
 
-[View Template](https://github.com/AgentOps-AI/AgentStack/blob/main/agentstack/templates/proj_templates/system_analyzer.json)
+[View Template](https://github.com/AgentOps-AI/AgentStack/blob/main/agentstack/templates/system_analyzer.json)
 
 ```bash
 agentstack init --template=system_analyzer
@@ -737,7 +733,7 @@ title: 'Researcher'
 description: 'Research and report result from a query'
 ---
 
-[View Template](https://github.com/AgentOps-AI/AgentStack/blob/main/agentstack/templates/proj_templates/research.json)
+[View Template](https://github.com/AgentOps-AI/AgentStack/blob/main/agentstack/templates/research.json)
 
 ```bash
 agentstack init --template=research
@@ -828,7 +824,54 @@ title: 'Content Creator'
 description: 'Research a topic and create content on it'
 ---
 
-[View Template](https://github.com/AgentOps-AI/AgentStack/blob/main/agentstack/templates/proj_templates/content_creator.json)
+[View Template](https://github.com/AgentOps-AI/AgentStack/blob/main/agentstack/templates/content_creator.json)
+
+## frameworks/list.mdx
+
+---
+title: Frameworks
+description: 'Supported frameworks in AgentStack'
+icon: 'ship'
+---
+
+These are documentation links to the frameworks supported directly by AgentStack.
+
+To start a project with one of these frameworks, use
+```bash
+agentstack init <project_name> --framework <framework_name>
+```
+
+## Framework Docs
+<CardGroup cols={3}>
+  <Card
+    title="CrewAI"
+    icon="ship"
+    href="https://docs.crewai.com/introduction"
+  >
+    An intuitive agentic framework (recommended)
+  </Card>
+    <Card
+    title="LangGraph"
+    icon="circle-nodes"
+    href="https://langchain-ai.github.io/langgraph/"
+  >
+    A complex but capable framework with a _steep_ learning curve
+  </Card>
+    <Card
+    title="OpenAI Swarms"
+    icon="bee"
+    href="https://github.com/openai/swarm"
+  >
+    A simple framework with a cult following
+  </Card>
+    <Card
+    title="LlamaIndex"
+    icon="layer-group"
+    href="https://docs.llamaindex.ai/en/stable/"
+  >
+    An expansive framework with many ancillary features
+  </Card>
+</CardGroup>
 
 ## tools/package-structure.mdx
 
@@ -1043,7 +1086,7 @@ You can pass the `--wizard` flag to `agentstack init` to use an interactive proj
 You can also pass a `--template=<template_name>` argument to `agentstack init` which will pre-populate your project with functionality
 from a built-in template, or one found on the internet. A `template_name` can be one of three identifiers:
 
-- A built-in AgentStack template (see the `templates/proj_templates` directory in the AgentStack repo for bundled templates).
+- A built-in AgentStack template (see the `templates` directory in the AgentStack repo for bundled templates).
 - A template file from the internet; pass the full https URL of the template.
 - A local template file; pass an absolute or relative path. 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 
 dependencies = [
-    "agentops>=0.3.18",
+    "agentops==0.3.18",
     "typer>=0.12.5",
     "inquirer>=3.4.0",
     "art>=6.3",
@@ -33,7 +33,10 @@ dependencies = [
     "uv>=0.5.6",
     "tomli>=2.2.1",
     "gitpython>=3.1.44",
-    "websockets>=14.2"
+    "websockets>=14.2",
+    "flask>=3.1.0",
+    "flask-sock>=0.7.0",
+    "flask-cors>=5.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
- [x] Shared logic for running user projects between `serve` and `cli`
- [x] Added a new log method `log.stream` which can be appended to (doesn't insert newlines).
- [x] Added a new log handler for streaming log information to other parts of the app (preserves existing `stdout`/`stderr`)
- [x] Allows `custom` framework to be executed but not modified. 
- [ ] Is messy; cleanup serve.py
- [ ] Docker needs more work

Currently testing this inside a project dir with: `python ../AgentStack/agentstack/serve/serve.py`
