### PR TITLE
GitHub action for calculating checksums on release.

### DIFF
--- a/.github/workflows/release-checksum.yml
+++ b/.github/workflows/release-checksum.yml
@@ -1,0 +1,23 @@
+name: Create checksum.txt for releases
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: macos-latest
+
+    steps:
+      - name: Run checksum action
+        uses: thewh1teagle/checksum@v1
+        with:
+          patterns: |
+            *.zip
+            *.tar.gz
+          algorithm: sha256
+          dry-run: checksum.txt
+        env:
+          # You must enable write permission in github.com/user/repo/settings/actions -> Workflow permissions -> Read and write permissions
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- [ ] Has a flag to `dry-run` currently. 