### PR TITLE
Set X-TF-Request-Origin header in AgentQL tool

### DIFF
--- a/agentstack/_tools/agentql/__init__.py
+++ b/agentstack/_tools/agentql/__init__.py
@@ -47,7 +47,11 @@ def extract_data(url: str, query: Optional[str], prompt: Optional[str]) -> dict:
     """
     payload = {"url": url, "query": query, "prompt": prompt}
 
-    headers = {"X-API-Key": f"{API_KEY}", "Content-Type": "application/json"}
+    headers = {
+        "X-API-Key": f"{API_KEY}",
+        "Content-Type": "application/json",
+        "X-TF-Request-Origin": "agentstack",
+    }
 
     try:
         response = httpx.post(


### PR DESCRIPTION
## 📥 Pull Request

**📘 Description**
This PR adds a new header to the extract_data tool in AgentQL to specify the request origin.

- Add the "X-TF-Request-Origin": "agentstack" header to the headers dictionary

